### PR TITLE
fix arg name: remove_flashes -> remove-flashes

### DIFF
--- a/src/ctrando/arguments/postrandooptions.py
+++ b/src/ctrando/arguments/postrandooptions.py
@@ -247,7 +247,7 @@ class PostRandoOptions:
         )
 
         group.add_argument(
-            "--remove_flashes", action="store_true",
+            "--remove-flashes", action="store_true",
             help="Remove flashes from many animations."
         )
 


### PR DESCRIPTION
This fixes a web generator error where it tries to use the wrong name for the remove-flashes argument and causes the toml builder form to fail.