### PR TITLE
Fix plando start character default value

### DIFF
--- a/src/ctrando/arguments/plandooptions.py
+++ b/src/ctrando/arguments/plandooptions.py
@@ -91,7 +91,7 @@ class PlandoOptions:
 
             if recruit_id == ctenums.RecruitID.STARTER:
                 ret_dict[name] = argumenttypes.MultipleDiscreteSelection(
-                    list(ctenums.CharID) + ["random"], "random",
+                    list(ctenums.CharID) + ["random"], ["random"],
                     "Characters to start with",
                     lambda x: _plando_recruit_dict[x],
                     lambda x: _plando_recruit_dict_inv[x],


### PR DESCRIPTION
The string was being treated as a list with each letter as a separate entry.  Converted the value to a list containing the string "random"