### PR TITLE
Add pacifist to starter rewards choice lists

### DIFF
--- a/src/ctrando/arguments/logicoptions.py
+++ b/src/ctrando/arguments/logicoptions.py
@@ -29,6 +29,7 @@ _reward_dict: dict[str, RewardType] = {
     "bangor_pillar": memory.Flags.HAS_BANGOR_PORTAL,
     "truce_pillar": memory.Flags.HAS_TRUCE_PORTAL,
     "desert": memory.Flags.PLANT_LADY_SAVES_SEED,
+    "pacifist": ctenums.ItemID.PACIFIST,
 }
 
 _inverse_reward_dict: dict[RewardType, str] = {


### PR DESCRIPTION
I added the pacifist to the rewards list.  It looks like this list is only use for starter rewards and out-of-logic starter rewards, which I assume is the only place we want pacifist to show up?  Let me know if you don't want it in this list and I can try to handle it separately.