### PR TITLE
Fix Choras Market 600 OW exit

### DIFF
--- a/src/ctrando/overworlds/owexitdata.py
+++ b/src/ctrando/overworlds/owexitdata.py
@@ -357,7 +357,8 @@ class OWExitClass(enum.Enum):
     CHORAS_CARPENTER_600 = (OWExitEnum.CHORAS_CARPENTER_600_NE, OWExitEnum.CHORAS_CARPENTER_600_N,
                             OWExitEnum.CHORAS_CARPENTER_600_NW)
     CHORAS_MARKET_600 = (OWExitEnum.CHORAS_MARKET_600_E, OWExitEnum.CHORAS_MARKET_600_SE,
-                         OWExitEnum.CHORAS_MARKET_600_S, OWExitEnum.CHORAS_MARKET_600_W)
+                         OWExitEnum.CHORAS_MARKET_600_S, OWExitEnum.CHORAS_MARKET_600_W,
+                         OWExitEnum.CHORAS_MARKET_600)
     CURSED_WOODS = (OWExitEnum.CURSED_WOODS,)
     DENADORO_MTS = (OWExitEnum.DENADORO_MTS,)
     MAGIC_CAVE_MAGUS = (OWExitEnum.MAGIC_CAVE_MAGUS,)


### PR DESCRIPTION
One of the market exits was missing from the owexit definition. This caused the one tile to connect to the default market location intead of the new location in entrance rando seeds.