### PR TITLE
Add numpy dependency to pyproject file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ classifiers = [
 ]
 license = "MIT"
 license-files = ["LICEN[CS]E*"]
+dependencies = [
+    "numpy==2.5.1",
+]
 
 [tool.setuptools]
 ext-modules = [


### PR DESCRIPTION
Adds numpy to the dependencies section of the pyproject file.  This automatically installs numpy when the rando package is installed.  The version (2.5.1) is just what I got when I installed numpy through pip on python 3.12.  I'm willing to change that if you have a preferred version.